### PR TITLE
Bump org.apache.logging.log4j:log4j-to-slf4j from 2.20.0 to 2.22.0

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
             version { require("3.4.22") }
         }
         // CVEs
-        api("org.apache.logging.log4j:log4j-to-slf4j:2.20.0") {
+        api("org.apache.logging.log4j:log4j-to-slf4j:2.22.0") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
          api("org.apache.logging.log4j:log4j-api:2.20.0") {


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-to-slf4j from 2.20.0 to 2.22.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-to-slf4j dependency-type: direct:production update-type: version-update:semver-minor ...

Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

